### PR TITLE
add subs for content and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Available `options`:
 }
 ```
 
-### `await seed.putProperty(key, value)`
+### `await seed.metadata.put(key, value)`
 
 Add a new Seedbee metadata value.
 
@@ -98,9 +98,13 @@ const value = '*'
 await seed.putProperty(key, value)
 ```
 
-### `await seed.getProperty(key)`
+### `await seed.metadata.get(key)`
 
 Read a Seedbee metadata value.
+
+### `await seed.metadata.del(key)`
+
+Delete a Seedbee metadata value.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ Available `options`:
 Add a new Seedbee metadata value.
 
 ``` js
-const key = SeedBee.ALLOWED_PEERS_METADATA_KEY
+const key = 'key'
 const value = '*'
-await seed.putProperty(key, value)
+await seed.metadata.put(key, value)
 ```
 
 ### `await seed.metadata.get(key)`

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ const value = '*'
 await seed.metadata.put(key, value)
 ```
 
-### `await seed.metadata.get(key)`
+### `const value = await seed.metadata.get(key)`
 
 Read a Seedbee metadata value.
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,21 @@ Available `options`:
 }
 ```
 
+### `await seed.putProperty(key, value)`
+
+Add a new Seedbee metadata value.
+
+``` js
+const key = SeedBee.ALLOWED_PEERS_METADATA_KEY
+const value = '*'
+await seed.putProperty(key, value)
+```
+
+### `await seed.getProperty(key)`
+
+Read a Seedbee metadata value.
+
+
 ## License
 
 Apache-2.0

--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ Read a Seedbee metadata value.
 
 Delete a Seedbee metadata value.
 
-
 ## License
 
 Apache-2.0

--- a/encoding.js
+++ b/encoding.js
@@ -1,6 +1,8 @@
+const SubEncoder = require('sub-encoder')
 const c = require('compact-encoding')
+const b4a = require('b4a')
 
-const contentKeyEncoding = c.fixed32
+const enc = new SubEncoder()
 
 const contentValueEncoding = {
   preencode (state, v) {
@@ -22,4 +24,13 @@ const contentValueEncoding = {
   }
 }
 
-module.exports = { contentKeyEncoding, contentValueEncoding }
+module.exports = {
+  contentEncoding: {
+    keyEncoding: enc.sub(b4a.from([0]), { keyEncoding: c.fixed32 }),
+    valueEncoding: contentValueEncoding
+  },
+  metadataEncoding: {
+    keyEncoding: enc.sub(b4a.from([1]), { keyEncoding: 'utf-8' }),
+    valueEncoding: 'utf-8'
+  }
+}

--- a/encoding.js
+++ b/encoding.js
@@ -1,8 +1,8 @@
 const c = require('compact-encoding')
 
-const keyEncoding = c.fixed32
+const contentKeyEncoding = c.fixed32
 
-const valueEncoding = {
+const contentValueEncoding = {
   preencode (state, v) {
     c.string.preencode(state, v.type)
     c.string.preencode(state, v.description)
@@ -22,4 +22,4 @@ const valueEncoding = {
   }
 }
 
-module.exports = { keyEncoding, valueEncoding }
+module.exports = { contentKeyEncoding, contentValueEncoding }

--- a/encoding.js
+++ b/encoding.js
@@ -31,6 +31,6 @@ module.exports = {
   },
   metadataEncoding: {
     keyEncoding: enc.sub(b4a.from([1]), { keyEncoding: 'utf-8' }),
-    valueEncoding: 'utf-8'
+    valueEncoding: c.any
   }
 }

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = class SeedBee extends ReadyResource {
 
   async get (key, opts) {
     key = Id.decode(key)
-    const entry = await this.bee.get(key, { ...contentEncoding, ...opts })
+    const entry = await this.bee.get(key, { ...opts, ...contentEncoding })
     return entry ? entry.value : null
   }
 
@@ -49,7 +49,7 @@ module.exports = class SeedBee extends ReadyResource {
   }
 
   async * entries (opts = {}) {
-    for await (const e of this.bee.createReadStream({ ...contentEncoding, ...opts })) {
+    for await (const e of this.bee.createReadStream({ ...opts, ...contentEncoding })) {
       if (opts.type && opts.type !== e.value.type) continue
       yield e
     }

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = class SeedBee extends ReadyResource {
 
     this.core = core
     this.bee = new Hyperbee(core)
+    this.metadata = new Metadata(this.bee)
   }
 
   _open () {
@@ -19,15 +20,6 @@ module.exports = class SeedBee extends ReadyResource {
 
   _close () {
     return this.bee.close()
-  }
-
-  putProperty (key, value) {
-    return this.bee.put(key, value, metadataEncoding)
-  }
-
-  async getProperty (key) {
-    const entry = await this.bee.get(key, metadataEncoding)
-    return entry ? entry.value : null
   }
 
   async put (key, opts = {}) {
@@ -61,6 +53,25 @@ module.exports = class SeedBee extends ReadyResource {
       if (opts.type && opts.type !== e.value.type) continue
       yield e
     }
+  }
+}
+
+class Metadata {
+  constructor (bee) {
+    this.bee = bee
+  }
+
+  put (key, value) {
+    return this.bee.put(key, value, metadataEncoding)
+  }
+
+  del (key) {
+    return this.bee.del(key, metadataEncoding)
+  }
+
+  async get (key) {
+    const entry = await this.bee.get(key, metadataEncoding)
+    return entry ? entry.value : null
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -13,8 +13,6 @@ module.exports = class SeedBee extends ReadyResource {
     this.bee = new Hyperbee(core)
   }
 
-  static ALLOWED_PEERS_METADATA_KEY = 'allowed-peers'
-
   _open () {
     return this.bee.ready()
   }

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = class SeedBee extends ReadyResource {
   }
 
   async * entries (opts = {}) {
-    for await (const e of this.bee.createReadStream({ ...opts, ...contentEncoding })) {
+    for await (const e of this.bee.createReadStream(contentEncoding)) {
       if (opts.type && opts.type !== e.value.type) continue
       yield e
     }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/holepunchto/seedbee#readme",
   "dependencies": {
+    "b4a": "^1.6.4",
     "compact-encoding": "^2.12.0",
     "hyperbee": "^2.13.1",
     "hypercore-id-encoding": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "compact-encoding": "^2.12.0",
     "hyperbee": "^2.13.1",
     "hypercore-id-encoding": "^1.1.0",
-    "ready-resource": "^1.0.0"
+    "ready-resource": "^1.0.0",
+    "sub-encoder": "^2.1.1"
   },
   "devDependencies": {
     "brittle": "^3.1.3",

--- a/test.js
+++ b/test.js
@@ -126,7 +126,7 @@ test('put/get metadata', async function (t) {
   t.plan(1)
 
   const seed = new SeedBee(new Hypercore(RAM))
-  const key = SeedBee.ALLOWED_PEERS_METADATA_KEY
+  const key = 'key'
   const value = '*'
 
   await seed.putProperty(key, value)
@@ -139,7 +139,7 @@ test('get empty metadata', async function (t) {
   t.plan(1)
 
   const seed = new SeedBee(new Hypercore(RAM))
-  const key = SeedBee.ALLOWED_PEERS_METADATA_KEY
+  const key = 'key'
 
   t.is(null, await seed.getProperty(key))
 

--- a/test.js
+++ b/test.js
@@ -123,27 +123,18 @@ test('invalid encoding values', async function (t) {
 })
 
 test('put/get/del metadata', async function (t) {
-  t.plan(2)
+  t.plan(3)
 
   const seed = new SeedBee(new Hypercore(RAM))
   const key = 'key'
   const value = '*'
 
+  t.is(null, await seed.metadata.get(key))
+
   await seed.metadata.put(key, value)
   t.is(value, await seed.metadata.get(key))
 
   await seed.metadata.del(key)
-  t.is(null, await seed.metadata.get(key))
-
-  await seed.close()
-})
-
-test('get empty metadata', async function (t) {
-  t.plan(1)
-
-  const seed = new SeedBee(new Hypercore(RAM))
-  const key = 'key'
-
   t.is(null, await seed.metadata.get(key))
 
   await seed.close()

--- a/test.js
+++ b/test.js
@@ -122,15 +122,18 @@ test('invalid encoding values', async function (t) {
   await seed.close()
 })
 
-test('put/get metadata', async function (t) {
-  t.plan(1)
+test('put/get/del metadata', async function (t) {
+  t.plan(2)
 
   const seed = new SeedBee(new Hypercore(RAM))
   const key = 'key'
   const value = '*'
 
-  await seed.putProperty(key, value)
-  t.is(value, await seed.getProperty(key))
+  await seed.metadata.put(key, value)
+  t.is(value, await seed.metadata.get(key))
+
+  await seed.metadata.del(key)
+  t.is(null, await seed.metadata.get(key))
 
   await seed.close()
 })
@@ -141,7 +144,7 @@ test('get empty metadata', async function (t) {
   const seed = new SeedBee(new Hypercore(RAM))
   const key = 'key'
 
-  t.is(null, await seed.getProperty(key))
+  t.is(null, await seed.metadata.get(key))
 
   await seed.close()
 })

--- a/test.js
+++ b/test.js
@@ -7,12 +7,14 @@ const Id = require('hypercore-id-encoding')
 const K = 'fbh6h7j9xgpsqeyke9rtzbcyowwobxfozhr3ukz9x64kf9zok41o'
 
 test('basic', async function (t) {
-  t.plan(6)
+  t.plan(8)
 
   const seed = new SeedBee(new Hypercore(RAM))
 
   t.ok(seed.core)
   t.ok(seed.bee)
+  t.ok(seed.content)
+  t.ok(seed.metadata)
 
   await seed.put(K, { type: 'core' })
 
@@ -118,6 +120,30 @@ test('invalid encoding values', async function (t) {
   } catch (err) {
     t.is(err.code, 'ERR_INVALID_ARG_TYPE') // CompactEncoding error
   }
+
+  await seed.close()
+})
+
+test('put/get metadata', async function (t) {
+  t.plan(1)
+
+  const seed = new SeedBee(new Hypercore(RAM))
+  const key = 'allowed-peers'
+  const value = '*'
+
+  await seed.putProperty(key, value)
+  t.is(value, await seed.getProperty(key))
+
+  await seed.close()
+})
+
+test('get empty metadata', async function (t) {
+  t.plan(1)
+
+  const seed = new SeedBee(new Hypercore(RAM))
+  const key = 'allowed-peers'
+
+  t.is(null, await seed.getProperty(key))
 
   await seed.close()
 })

--- a/test.js
+++ b/test.js
@@ -7,14 +7,12 @@ const Id = require('hypercore-id-encoding')
 const K = 'fbh6h7j9xgpsqeyke9rtzbcyowwobxfozhr3ukz9x64kf9zok41o'
 
 test('basic', async function (t) {
-  t.plan(8)
+  t.plan(6)
 
   const seed = new SeedBee(new Hypercore(RAM))
 
   t.ok(seed.core)
   t.ok(seed.bee)
-  t.ok(seed.content)
-  t.ok(seed.metadata)
 
   await seed.put(K, { type: 'core' })
 

--- a/test.js
+++ b/test.js
@@ -126,7 +126,7 @@ test('put/get metadata', async function (t) {
   t.plan(1)
 
   const seed = new SeedBee(new Hypercore(RAM))
-  const key = 'allowed-peers'
+  const key = SeedBee.ALLOWED_PEERS_METADATA_KEY
   const value = '*'
 
   await seed.putProperty(key, value)
@@ -139,7 +139,7 @@ test('get empty metadata', async function (t) {
   t.plan(1)
 
   const seed = new SeedBee(new Hypercore(RAM))
-  const key = 'allowed-peers'
+  const key = SeedBee.ALLOWED_PEERS_METADATA_KEY
 
   t.is(null, await seed.getProperty(key))
 


### PR DESCRIPTION
This pull request splits the seedbee database into two different sub-encodings. One sub-encode will store the seeded keys, preserving the key/value encodings. The other sub-encode will store the seedbee metadata, including information about allowed peers.